### PR TITLE
Added option to ignore .git directory for pkgdiff

### DIFF
--- a/pkgdiff
+++ b/pkgdiff
@@ -3,14 +3,8 @@
 
 set -e -x
 
-ignore_git_dir=${1}
-if [ "${ignore_git_dir}" = '--ignore-git-dir' ]; then
-	exclude_pattern=".git"
-	shift
-fi
-
 tmpdir=$(portageq envvar PORTAGE_TMPDIR)
 ebuild "${1}" unpack
 ebuild "${2}" unpack
-diff -dupNr --exclude="${exclude_pattern}" "${tmpdir}"/portage/*/${1%.ebuild}/work/* \
+diff -dupNr --exclude=".git" "${tmpdir}"/portage/*/${1%.ebuild}/work/* \
 	"${tmpdir}"/portage/*/${2%.ebuild}/work/* | ${PAGER:-less}

--- a/pkgdiff
+++ b/pkgdiff
@@ -3,8 +3,14 @@
 
 set -e -x
 
+ignore_git_dir=${1}
+if [ "${ignore_git_dir}" = '--ignore-git-dir' ]; then
+	exclude_pattern=".git"
+	shift
+fi
+
 tmpdir=$(portageq envvar PORTAGE_TMPDIR)
 ebuild "${1}" unpack
 ebuild "${2}" unpack
-diff -dupNr "${tmpdir}"/portage/*/${1%.ebuild}/work/* \
+diff -dupNr --exclude="${exclude_pattern}" "${tmpdir}"/portage/*/${1%.ebuild}/work/* \
 	"${tmpdir}"/portage/*/${2%.ebuild}/work/* | ${PAGER:-less}


### PR DESCRIPTION
Dear Michał,

First of all, thank you very much for the set of scripts that you developed. 

Using pkgbump and pkgdiff while working with git-based ebuilds I noticed myself skipping the section that shows the difference in `.git` directory quite often. I wrote a small addition to `pkgdiff` that excludes `.git` from diff if `--ignore-git-dir` is passed as the first parameter. If it is not passed - the utility behavior is not changed.