### PR TITLE
pkgdiff: Pass --color=always to diff

### DIFF
--- a/pkgdiff
+++ b/pkgdiff
@@ -8,4 +8,4 @@ ebuild "${1}" unpack
 ebuild "${2}" unpack
 s1=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${tmpdir}"/portage/*/${1%.ebuild}/temp/environment)
 s2=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${tmpdir}"/portage/*/${2%.ebuild}/temp/environment)
-diff --strip-trailing-cr -dupNr "${s1}" "${s2}" | ${PAGER:-less}
+diff --color=always --strip-trailing-cr -dupNr "${s1}" "${s2}" | ${PAGER:-less}


### PR DESCRIPTION
````
Makes reading the diffs much easier.

Signed-off-by: Matt Turner <mattst88@gentoo.org>
````

I don't know if there's a reason to not do this. Maybe some `PAGER` doesn't support colors or something...?