### PR TITLE
Use pkgdev manifest instead of repoman manifest

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,7 +71,7 @@ usage::
     cd foo/bar
     git rm bar-1.ebuild
     check-revdep
-    repoman manifest
+    pkgdev manifest
     pkgcommit -sS . -m 'Remove old'
 
 Uses rdep_ command.  You may want to call ``rdep-fetch-cache`` if you
@@ -149,11 +149,11 @@ Typical usage::
 
     llvm-foreach-pkg sh -c 'x=( *14.0.0.9999* ); cp ${x} ${x/.9999}'
     git add -A
-    GENTOO_MIRRORS= repoman manifest --if-modified=y
+    pkgdev manifest
     llvm-foreach-pkg pkgcommit -sS . -m "Bump to 14.0.0"
 
     llvm-foreach-pkg sh -c 'git rm *14.0.0_rc4*'
-    GENTOO_MIRRORS= repoman manifest --if-modified=y
+    pkgdev manifest
     llvm-foreach-pkg-rev pkgcommit -sS . -m "Remove 14.0.0_rc4"
 
 if-multiple-versions

--- a/bump-kernels
+++ b/bump-kernels
@@ -20,7 +20,7 @@ while [[ ${#} -gt 0 ]]; do
 			ekeyword ~all "${newk}"
 			"${scriptdir}"/copybump "${newk}"
 			${EDITOR:-vim} "${newk}"
-			GENTOO_MIRRORS= repoman manifest
+			GENTOO_MIRRORS= ebuild "${newk}" manifest
 
 			# do verify-sig
 			if [[ ${pkg} == vanilla-kernel ]]; then

--- a/bump-kernels-bin
+++ b/bump-kernels-bin
@@ -31,7 +31,7 @@ while [[ ${#} -gt 0 ]]; do
 			ekeyword ~all "${newk}"
 			"${scriptdir}"/copybump "${newk}"
 			${EDITOR:-vim} "${newk}"
-			GENTOO_MIRRORS= repoman manifest
+			GENTOO_MIRRORS= ebuild "${newk}" manifest
 
 			git add Manifest "${newk}"
 			"${scriptdir}"/pkgcommit -sS . -m "Bump to ${new}"

--- a/pkgbump
+++ b/pkgbump
@@ -6,6 +6,6 @@ scriptdir=${BASH_SOURCE%/*}
 cp "${1}" "${2}"
 "${scriptdir}"/copybump "${2}"
 ekeyword ~all "${2}"
-GENTOO_MIRRORS= repoman manifest
+GENTOO_MIRRORS= ebuild "${2}" manifest
 git add Manifest "${2}"
 exec "${scriptdir}"/pkgdiff "${1}" "${2}"


### PR DESCRIPTION
pkgdev manifest also doesn't use mirrors by default (the -m, --mirrors
option enables it), so we don't need to override GENTOO_MIRRORS.

Signed-off-by: Matt Turner <mattst88@gentoo.org>