### PR TITLE
stablereq-find-candidates: Add new script

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -81,15 +81,15 @@ pkgdiff
 -------
 Dependencies: portage
 
-Calls `ebuild(1)` to extract archives for two specified ebuilds,
+Calls ``ebuild(1)`` to extract archives for two specified ebuilds,
 and then diffs the result.  Does not handle ebuilds unpacking multiple
 directories into workdir or package.env PORTAGE_TMPDIR overrides.
 Typical usage::
 
     pkgdiff foo-1.0.ebuild foo-1.1.ebuild
 
-With the `--build-system`/`-b` argument, it will attempt to show a diff of
-only the build system files.
+With the ``--build-system``/``-b`` argument, it will attempt to show a diff of
+only the build system files::
 
     pkgdiff --build-system foo-1.0.ebuild foo-1.1.ebuild
 

--- a/README.rst
+++ b/README.rst
@@ -321,6 +321,15 @@ accepts pkgcheck arguments.  Typical usage::
     stablereq-eshowkw 'dev-python/*'
 
 
+stablereq-find-candidates
+-------------------------
+Dependencies: pkgcheck
+
+Find stabilization candidates for a given maintainer. Typical usage::
+
+    stablereq-find-candidates x11@gentoo.org
+
+
 stablereq-find-pkg-bugs
 -----------------------
 Dependencies: pkgcheck, xdg-utils, perl

--- a/foreach-pkg-maint
+++ b/foreach-pkg-maint
@@ -8,7 +8,7 @@ maint=${1}
 shift
 
 cd "$(git rev-parse --show-toplevel)"
-exec 77< <(git grep -l "${maint}" '**/metadata.xml' | cut -d/ -f1-2)
+exec 77< <(git grep -l "${maint}" '*/*/metadata.xml' | cut -d/ -f1-2)
 
 while read -r -u 77 pkg; do
 	(

--- a/stablereq-find-candidates
+++ b/stablereq-find-candidates
@@ -1,0 +1,19 @@
+#!/bin/bash
+
+set -e
+
+if [[ ${#} -eq 0 ]]; then
+	echo "Usage: $0 <maintainer-email>"
+	exit
+fi
+maint=${1}
+
+cd "$(git rev-parse --show-toplevel)"
+
+echo " days │ category/package:slot"
+echo "──────┼────────────────────────────────────────────────────────────────────────"
+exec \
+	git grep -l "${maint}" '*/*/metadata.xml' |
+	cut -d/ -f1-2 |
+	xargs pkgcheck scan -k StableRequest -R FormatReporter --format " {age:4} │ {category}/{package}-{version}:{slot}" |
+	sort -k2


### PR DESCRIPTION
Finds package versions that are candidates to be stabilized, similar to
gentoolkit's imlate utility.

    % stablereq-find-candidates x11@gentoo.org
     Days │ category/package:SLOT
    ──────┼────────────────────────────────────────────────────────────────
       40 │ dev-cpp/robin-hood-hashing-3.11.5:0
       40 │ dev-libs/libinput-1.20.0:0
       40 │ dev-util/spirv-headers-1.3.204:0
       40 │ dev-util/spirv-tools-1.3.204:0
       40 │ dev-util/vulkan-headers-1.3.204:0
       40 │ dev-util/vulkan-tools-1.3.204:0
       48 │ media-libs/freeglut-3.2.2:0
       40 │ media-libs/vulkan-loader-1.3.204:0
       43 │ x11-base/xwayland-22.1.0:0
       67 │ x11-drivers/xf86-input-libinput-1.2.1:0
       36 │ x11-drivers/xf86-video-amdgpu-22.0.0:0
       43 │ x11-libs/libdrm-2.4.110:0
       53 │ x11-libs/libxkbcommon-1.4.0:0
       48 │ x11-misc/xkeyboard-config-2.35.1:0

 Signed-off-by: Matt Turner \<mattst88@gentoo.org\>