### PR TITLE
lr-commit-pmask: edit commit message

### DIFF
--- a/lr-commit-pmask
+++ b/lr-commit-pmask
@@ -16,7 +16,7 @@ pkg="${pkg[*]}"
 bugno=$(git diff -U0 profiles/package.mask |
 	sed -n -e 's/^+#.*Removal.* Bug #\([0-9]\+\)./\1/p')
 
-msg="package.mask: Last rite ${pkg// /, }${bugno:+
+msg="profiles/package.mask: Last rite ${pkg// /, }${bugno:+
 
 Bug: https://bugs.gentoo.org/${bugno}}"
 


### PR DESCRIPTION
Sam recently corrected a commit message on a PR of mine. I created the commit and its message with this tool. 
So, we should probably change the tools once instead of changing many commit messages in the future. 

https://github.com/gentoo/gentoo/pull/28405#issuecomment-1325831310