### PR TITLE
pkgdiff-mg: use /var/tmp instead of /tmp as default TMPDIR

### DIFF
--- a/pkgdiff-mg
+++ b/pkgdiff-mg
@@ -36,7 +36,13 @@ fn2=${2##*/}
 ver1=$(patom -F '%{fullver}' "=${cat1}/${fn1%.ebuild}")
 ver2=$(patom -F '%{fullver}' "=${cat2}/${fn2%.ebuild}")
 
-export PORTAGE_TMPDIR="${TMPDIR:-/tmp}"/mgorny-dev-scripts
+DEFAULT_TMPDIR=/tmp
+if [[ -d /run/systemd/system ]]; then
+	# System booted via systemd, which automatically cleans up stale
+	# files in /var/tmp.
+	DEFAULT_TMPDIR=/var/tmp
+fi
+export PORTAGE_TMPDIR="${TMPDIR:-${DEFAULT_TMPDIR}}"/mgorny-dev-scripts
 export USE="${USE} test"
 # use noauto to skip pkg_setup
 export FEATURES="${FEATURES} noauto"


### PR DESCRIPTION
pkgdiff can cause large files in the used temprorary directory that are not cleaned up on exit. Using /tmp for those, which is often a tmpfs, which means that the files consume main memory at first. Later the system may move the unused files on the tmpfs into swap.

In any case, using /var/tmp instead of /tmp as default TMPDIR for pkgdiff-mg is sensible. As a genral rule of thumb, /tmp should be used for smaller, size bounded files only; /var/tmp for everything else.