### PR TITLE
check-mismatched-packages: pass `--raw` to pquery

### DIFF
--- a/check-mismatched-packages
+++ b/check-mismatched-packages
@@ -25,7 +25,7 @@ while read -r PKG; do
 	VERSION=${VERSION%_p*}
 	VERSIONS[${NAME}:${SLOT}]=${VERSION}
 done < <(
-	pquery -q -r "${REPO}" --slot "${PKGS[@]%=*}" "${PKGS[@]#*=}"
+	pquery --raw --quiet --repo "${REPO}" --slot "${PKGS[@]%=*}" "${PKGS[@]#*=}"
 )
 
 RET=0


### PR DESCRIPTION
Without --raw, pquery depends on user's profile, which in our case, if a stable profile is used, only stable versions are compared.  This is fixed by passing --raw to pquery, which makes it compare all versions ignoring user's profile.