### PR TITLE
pkgdiff-mg: add CHANGELOG*

### DIFF
--- a/pkgdiff-mg
+++ b/pkgdiff-mg
@@ -71,6 +71,7 @@ s2=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${PORTAGE_TMPDIR}"/portage/${cat2}/$
 						-name 'META.json' -o \
 						-name 'NEWS*' -o \
 						-name 'CHANGES*' -o \
+						-name 'CHANGELOG*' -o \
 						-name 'Gemfile' -o \
 						-name 'Gemfile.lock' -o \
 						-name 'META' -o \


### PR DESCRIPTION
pkgcraft at least uses CHANGELOG.md. Note that I've deliberately not included ChangeLog since that usually indicates GNU-style ChangeLogs which aren't really useful to skim in most projects.