### PR TITLE
pkgdiff-mg: Add meson.options

### DIFF
--- a/pkgdiff-mg
+++ b/pkgdiff-mg
@@ -58,6 +58,7 @@ s2=$(sed -nr 's/^declare -x S="(.*)"/\1/p' "${PORTAGE_TMPDIR}"/portage/${cat2}/$
 						-name 'configure.ac' -o \
 						-name '*.m4' -o \
 						-name 'meson.build' -o \
+						-name 'meson.options' -o \
 						-name 'meson_options.txt' -o \
 						-name '*.cmake' -o \
 						-name 'CMakeLists.txt' -o \


### PR DESCRIPTION
This is the new name for meson_options.txt.