### PR TITLE
Kernel fixes

### DIFF
--- a/bump-kernels
+++ b/bump-kernels
@@ -16,7 +16,7 @@ while [[ ${#} -gt 0 ]]; do
 	for pkg in vanilla-kernel gentoo-kernel; do
 		new=${new_full}
 		[[ ${pkg} == vanilla-kernel ]] && new=${new%_p*}
-		[[ ${old} == ${new} ]] && continue
+		[[ ${old%*_p*} == ${new} ]] && continue
 
 		(
 			cd sys-kernel/${pkg}

--- a/mkpatchset
+++ b/mkpatchset
@@ -19,7 +19,7 @@ distdir=$(portageq distdir)
 git tag "${tag}"
 mkdir "${name}"
 cd "${name}"
-git format-patch "${upstream}"
+git format-patch --no-base --no-cover-letter "${upstream}"
 cd ..
 tar -cf "${name}".tar "${name}"
 xz -9e "${name}".tar


### PR DESCRIPTION
Otherwise for vanilla-kernel, we fail as no *_p exists to copy from when
we're doing e.g. _p1 -> _p2.

Signed-off-by: Sam James <sam@gentoo.org>